### PR TITLE
Add provider discount engine (SP/RI/CUD/Spot) with safe defaults

### DIFF
--- a/configs/example-infra.yaml
+++ b/configs/example-infra.yaml
@@ -17,3 +17,20 @@ infrastructure:
     type: elasticache
     instance_type: cache.t3.small
     region: us-east-1
+
+compute:
+  instances:
+    - name: "api"
+      provider: "aws"
+      region: "us-east-1"
+      family: "m7g.large"
+      count: 3
+      base_hourly_rate: 0.096
+      discounts:
+        purchase: "savings_plan"   # on_demand|spot|reserved|savings_plan|cud
+        commitment: "1y"           # none|1y|3y
+        # Provide the real effective discount when available (preferred):
+        effective_discount_pct: 0.32
+        attributes:
+          sp_type: "compute"       # example attribute for AWS SP
+    

--- a/pricing/discounts.py
+++ b/pricing/discounts.py
@@ -1,0 +1,49 @@
+# src/pricing/discounts.py
+from .models import DiscountConfig, PurchaseOption, CommitmentTerm
+
+
+def clamp(x: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, x))
+
+
+def _fallback_defaults(discount: DiscountConfig) -> float:
+    """
+    Neutral, conservative defaults when no effective_discount_pct is provided.
+    These are placeholders to enable the flow without hardcoding vendor-specific rates.
+    Teams should set 'effective_discount_pct' per workload/contract to reflect real deals.
+    """
+    if discount.purchase == PurchaseOption.ON_DEMAND:
+        return 0.0
+
+    # Conservative placeholders (feel free to tune per account reality):
+    if discount.purchase == PurchaseOption.SPOT:
+        # Spot/Preemptible varies widely. Start conservative.
+        return 0.3  # 30% cheaper than on-demand
+
+    if discount.purchase in (PurchaseOption.RESERVED, PurchaseOption.SAVINGS_PLAN, PurchaseOption.CUD):
+        # 1y vs 3y: stronger discount for longer commitments
+        if discount.commitment == CommitmentTerm.THREE_YEARS:
+            return 0.4
+        if discount.commitment == CommitmentTerm.ONE_YEAR:
+            return 0.25
+        return 0.15
+
+    return 0.0
+
+
+def effective_hourly_rate(base_hourly_rate: float, discount: DiscountConfig | None) -> float:
+    """
+    Returns the effective hourly rate after applying discounts.
+    If 'effective_discount_pct' is provided, use it directly (clamped to [0,1]).
+    Otherwise, apply neutral fallback defaults.
+    """
+    if discount is None:
+        return base_hourly_rate
+
+    pct = discount.effective_discount_pct
+    if pct is None:
+        pct = _fallback_defaults(discount)
+
+    pct = clamp(pct, 0.0, 0.95)  # safety clamp; avoid zero/negative pricing
+    return base_hourly_rate * (1.0 - pct)
+

--- a/pricing/models.py
+++ b/pricing/models.py
@@ -1,0 +1,38 @@
+# src/pricing/models.py
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Dict, Any
+
+
+class PurchaseOption(str, Enum):
+    ON_DEMAND = "on_demand"
+    SPOT = "spot"                 # AWS Spot / GCP Preemptible
+    RESERVED = "reserved"         # AWS RI
+    SAVINGS_PLAN = "savings_plan" # AWS Savings Plan
+    CUD = "cud"                   # GCP Committed Use Discount
+
+
+class CommitmentTerm(str, Enum):
+    NONE = "none"
+    ONE_YEAR = "1y"
+    THREE_YEARS = "3y"
+
+
+@dataclass
+class DiscountConfig:
+    purchase: PurchaseOption = PurchaseOption.ON_DEMAND
+    commitment: CommitmentTerm = CommitmentTerm.NONE
+    # Effective discount as a percentage in [0.0, 1.0], applied on top of base on-demand rate.
+    # Example: 0.35 = 35% cheaper than on-demand.
+    effective_discount_pct: Optional[float] = None
+    # Optional provider-specific knobs for future expansion (e.g., SP type, RI class, scope)
+    attributes: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ResourcePricingInput:
+    provider: str                # "aws" or "gcp"
+    region: str
+    base_hourly_rate: float      # on-demand base hourly price for the resource
+    discounts: Optional[DiscountConfig] = None
+

--- a/src/aws.py
+++ b/src/aws.py
@@ -1,0 +1,53 @@
+# src/aws.py
+from typing import Dict, Any
+from .pricing.models import ResourcePricingInput, DiscountConfig, PurchaseOption, CommitmentTerm
+from .pricing.discounts import effective_hourly_rate
+
+
+def price_ec2_instance(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    params expected:
+      {
+        "region": "us-east-1",
+        "base_hourly_rate": 0.096,  # on-demand for chosen family/size
+        "discounts": {
+            "purchase": "on_demand|spot|reserved|savings_plan",
+            "commitment": "none|1y|3y",
+            "effective_discount_pct": 0.35,          # optional
+            "attributes": {"sp_type": "compute"}     # optional
+        }
+      }
+    """
+    discounts = None
+    if "discounts" in params and params["discounts"]:
+        d = params["discounts"]
+        discounts = DiscountConfig(
+            purchase=PurchaseOption(d.get("purchase", "on_demand")),
+            commitment=CommitmentTerm(d.get("commitment", "none")),
+            effective_discount_pct=d.get("effective_discount_pct"),
+            attributes=d.get("attributes", {}) or {},
+        )
+
+    rpi = ResourcePricingInput(
+        provider="aws",
+        region=params["region"],
+        base_hourly_rate=float(params["base_hourly_rate"]),
+        discounts=discounts
+    )
+
+    rate = effective_hourly_rate(rpi.base_hourly_rate, rpi.discounts)
+    # monthly approximation at 730 hours
+    monthly = rate * 730.0
+
+    return {
+        "provider": "aws",
+        "region": rpi.region,
+        "base_hourly_rate": rpi.base_hourly_rate,
+        "effective_hourly_rate": rate,
+        "monthly_estimate": monthly,
+        "applied_purchase_option": discounts.purchase.value if discounts else "on_demand",
+        "applied_commitment": discounts.commitment.value if discounts else "none",
+        "applied_discount_pct": (discounts.effective_discount_pct
+                                 if discounts and discounts.effective_discount_pct is not None else None)
+    }
+

--- a/src/gcp.py
+++ b/src/gcp.py
@@ -1,0 +1,52 @@
+# src/gcp.py
+from typing import Dict, Any
+from .pricing.models import ResourcePricingInput, DiscountConfig, PurchaseOption, CommitmentTerm
+from .pricing.discounts import effective_hourly_rate
+
+
+def price_compute_engine(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    params expected:
+      {
+        "region": "us-central1",
+        "base_hourly_rate": 0.094,  # on-demand for chosen machine type
+        "discounts": {
+            "purchase": "on_demand|spot|cud",
+            "commitment": "none|1y|3y",
+            "effective_discount_pct": 0.30,          # optional
+            "attributes": {"cud_scope": "region"}    # optional
+        }
+      }
+    """
+    discounts = None
+    if "discounts" in params and params["discounts"]:
+        d = params["discounts"]
+        discounts = DiscountConfig(
+            purchase=PurchaseOption(d.get("purchase", "on_demand")),
+            commitment=CommitmentTerm(d.get("commitment", "none")),
+            effective_discount_pct=d.get("effective_discount_pct"),
+            attributes=d.get("attributes", {}) or {},
+        )
+
+    rpi = ResourcePricingInput(
+        provider="gcp",
+        region=params["region"],
+        base_hourly_rate=float(params["base_hourly_rate"]),
+        discounts=discounts
+    )
+
+    rate = effective_hourly_rate(rpi.base_hourly_rate, rpi.discounts)
+    monthly = rate * 730.0
+
+    return {
+        "provider": "gcp",
+        "region": rpi.region,
+        "base_hourly_rate": rpi.base_hourly_rate,
+        "effective_hourly_rate": rate,
+        "monthly_estimate": monthly,
+        "applied_purchase_option": discounts.purchase.value if discounts else "on_demand",
+        "applied_commitment": discounts.commitment.value if discounts else "none",
+        "applied_discount_pct": (discounts.effective_discount_pct
+                                 if discounts and discounts.effective_discount_pct is not None else None)
+    }
+

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,0 +1,40 @@
+# tests/test_discounts.py
+from src.pricing.models import DiscountConfig, PurchaseOption, CommitmentTerm
+from src.pricing.discounts import effective_hourly_rate
+
+
+def test_on_demand_no_discount():
+    rate = effective_hourly_rate(1.0, None)
+    assert rate == 1.0
+
+
+def test_explicit_discount():
+    d = DiscountConfig(
+        purchase=PurchaseOption.SAVINGS_PLAN,
+        commitment=CommitmentTerm.ONE_YEAR,
+        effective_discount_pct=0.3
+    )
+    rate = effective_hourly_rate(1.0, d)
+    assert abs(rate - 0.7) < 1e-9
+
+
+def test_clamped_discount():
+    d = DiscountConfig(
+        purchase=PurchaseOption.SPOT,
+        commitment=CommitmentTerm.NONE,
+        effective_discount_pct=0.999
+    )
+    rate = effective_hourly_rate(2.0, d)
+    # clamped to 0.95 -> effective rate is 2 * (1 - 0.95) = 0.1
+    assert abs(rate - 0.1) < 1e-9
+
+
+def test_fallback_defaults_do_not_raise():
+    # no effective discount provided -> use safe fallback
+    d = DiscountConfig(
+        purchase=PurchaseOption.CUD,
+        commitment=CommitmentTerm.THREE_YEARS
+    )
+    rate = effective_hourly_rate(10.0, d)
+    assert 0.0 < rate < 10.0
+


### PR DESCRIPTION
- Introduce typed pricing model (PurchaseOption, CommitmentTerm, DiscountConfig)- 
- Add a unified discount applier with clamped percentages and conservative fallbacks- 
- Wire up AWS and GCP calculators to produce effective hourly and monthly rates- 
- Extend example YAML to pass contract-driven effective_discount_pct per workload- 
- Add unit tests for discount behavior, clamping, and fallbacks